### PR TITLE
Change postBuildExtras to use cordova provided list

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -16,7 +16,7 @@
        specific language governing permissions and limitations
        under the License.
  */
-ext.postBuildExtras = {
+ext.cdvPluginPostBuildExtras << {
     def inAssetsDir = file("assets")
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")


### PR DESCRIPTION
This fixes the problem where multiple cordova plugins attempting to use the postBuildExtras in the gradle script will simply clobber each other. The cordova provided gradle template provides a defined list for plugins to add their post build extras to so they can all play nicely together.

https://github.com/apache/cordova-android/blob/73edf4de7b751ecc103e9fad3c6d71c149c9118e/bin/templates/project/app/build.gradle#L90

This fixes the problems outlined in: 
https://github.com/meteor/meteor/issues/7600
https://github.com/raix/push/issues/334